### PR TITLE
Added missing requirement bs4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.18.1
 mechanize==0.2.5
+bs4==0.0.1


### PR DESCRIPTION
[DNSDumpsterAPI](https://github.com/UltimateHackers/Striker/blob/master/plugins/DNSDumpsterAPI.py#L12) requires bs4.